### PR TITLE
Add `ordered_at` + `order_total` to `orders` mart

### DIFF
--- a/models/marts/_marts.yml
+++ b/models/marts/_marts.yml
@@ -21,7 +21,9 @@ models:
         data_type: text
       - name: ordered_at
         data_type: timestamp
+      - name: order_total
+        data_type: numeric
       - name: total_jaffles_purchased
-        data_type: BIGINT
+        data_type: bigint
       - name: total_jaffle_revenue
-        data_type: NUMERIC
+        data_type: numeric

--- a/models/marts/_marts.yml
+++ b/models/marts/_marts.yml
@@ -19,6 +19,8 @@ models:
         data_type: text
       - name: customer_id
         data_type: text
+      - name: ordered_at
+        data_type: timestamp
       - name: total_jaffles_purchased
         data_type: BIGINT
       - name: total_jaffle_revenue

--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -26,6 +26,7 @@ unioned as (
         cast(order_id as text) as order_id,
         cast(customer_id as text) as customer_id,
         ordered_at,
+        order_total,
         coalesce(count_food_items, 0) as total_jaffles_purchased,
         coalesce(food_order_items_subtotal, 0) as total_jaffle_revenue
     
@@ -39,6 +40,7 @@ unioned as (
         cast(concession_sale_id as text) as order_id,
         cast(customer_id as text) as customer_id,
         sold_at as ordered_at,
+        order_subtotal as order_total,
         coalesce(total_jaffles_purchased, 0) as total_jaffles_purchased,
         coalesce(order_jaffle_subtotal, 0) as total_jaffle_revenue
     

--- a/models/marts/orders.sql
+++ b/models/marts/orders.sql
@@ -25,6 +25,7 @@ unioned as (
         location_id,
         cast(order_id as text) as order_id,
         cast(customer_id as text) as customer_id,
+        ordered_at,
         coalesce(count_food_items, 0) as total_jaffles_purchased,
         coalesce(food_order_items_subtotal, 0) as total_jaffle_revenue
     
@@ -37,6 +38,7 @@ unioned as (
         cirque_location.location_id,
         cast(concession_sale_id as text) as order_id,
         cast(customer_id as text) as customer_id,
+        sold_at as ordered_at,
         coalesce(total_jaffles_purchased, 0) as total_jaffles_purchased,
         coalesce(order_jaffle_subtotal, 0) as total_jaffle_revenue
     


### PR DESCRIPTION
Add `ordered_at` + `order_total` columns to reach parity with previous `orders` model, as needed in `jaffle_shop_mesh_marketing.customers`